### PR TITLE
fix: use waitFor to enable proper cancellation of pipette operations

### DIFF
--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -159,7 +159,7 @@ class PipetteMotionPlanner:
     For example, moving to a pipette search position involves setting the focus to a certain height, followed by
     positioning the pipette tip at that height and in the field of view.
     """
-    def __init__(self, pip: Pipette, position: Union[np.ndarray, str], speed: float, **kwds):
+    def __init__(self, pip: Pipette, position: Union[np.ndarray, str], speed: float | str, **kwds):
         self.pip = pip
         self.position = position
         self.speed = speed


### PR DESCRIPTION
## Summary
- Wraps async operations in `findNewPipette` with `_future.waitFor()` to ensure futures are properly tracked and can be cancelled
- Updates `PipetteMotionPlanner` type annotation to accept both `float` and `str` for speed parameter

## Changes
- **acq4/devices/Pipette/calibration.py**: Replaced direct `.wait()` calls with `_future.waitFor()` wrapper for:  - `imager.acquireFrames()`
  - `pipette._moveToGlobal()`
  - `acquire_z_stack()`
- **acq4/devices/Pipette/planners.py**: Updated speed parameter type hint from `float` to `float | str`

## Test plan
- [ ] Verify pipette search can be initiated successfully
- [ ] Verify canceling during z-stack acquisition properly stops all movement
- [ ] Verify canceling during pipette movement stops the operation
- [ ] Verify normal completion of pipette search still works as expected

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)