### PR TITLE
Display each pressure source as its own line

### DIFF
--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -123,7 +123,7 @@ class Stage(Device, OptomechDevice):
         """Return a tuple of axis names implemented by this device, like ('x', 'y', 'z').
 
         The axes described in the above data structure correspond to the mechanical
-        actuators on the device; they do not necessarily correspond to the axes in the 
+        actuators on the device; they do not necessarily correspond to the axes in the
         global coordinate system or the local coordinate system of the device.
 
         This method must be reimplemented by subclasses.
@@ -132,15 +132,15 @@ class Stage(Device, OptomechDevice):
 
     def capabilities(self):
         """Return a structure describing the capabilities of this device::
-        
+
             {
                 'getPos': (x, y, z),      # bool: whether each axis can be read from the device
                 'setPos': (x, y, z),      # bool: whether each axis can be set on the device
                 'limits': (x, y, z),      # bool: whether limits can be set for each axis
             }
-            
+
         The axes described in the above data structure correspond to the mechanical
-        actuators on the device; they do not necessarily correspond to the axes in the 
+        actuators on the device; they do not necessarily correspond to the axes in the
         global coordinate system or the local coordinate system of the device.
 
         Subclasses must reimplement this method.
@@ -172,7 +172,7 @@ class Stage(Device, OptomechDevice):
 
     def stageTransform(self):
         """Return the transform that implements the translation/rotation generated
-        by the current hardware state. 
+        by the current hardware state.
         """
         return pg.SRTTransform3D(self._stageTransform)
 
@@ -191,7 +191,7 @@ class Stage(Device, OptomechDevice):
         If the inverse transform is None, then it will be automatically generated
         on demand by calling transform.inverted().
 
-        Subclasses may override this method; the default uses _axisTransform to 
+        Subclasses may override this method; the default uses _axisTransform to
         map from the device position to a 3D translation matrix. This covers only cases
         where the stage axes perform linear translations. For rotation or nonlinear
         movement, this method must be reimplemented.
@@ -212,7 +212,7 @@ class Stage(Device, OptomechDevice):
 
         The default implementation simply inverts _axisTransform to generate this solution;
         devices with more complex kinematics need to reimplement this method.
-        """ 
+        """
         tr = self.stageTransform().getTranslation() + pg.Vector(posChange)
         return pg.Vector(self.inverseAxisTransform().map(tr))
 
@@ -245,7 +245,7 @@ class Stage(Device, OptomechDevice):
     def calculatedAxisOrientation(self, axis: str):
         """Return the pitch and yaw of a stage axis.
 
-        The pitch is returned in degrees relative to global horizontal (positive values point downward), 
+        The pitch is returned in degrees relative to global horizontal (positive values point downward),
         whereas the yaw is returned in degrees around the global Z axis relative to the global +X direction.
 
         The *axis* argument specifies which axis to return, one of '+x', '-x', '+y', '-y', '+z', or '-z'.
@@ -312,9 +312,9 @@ class Stage(Device, OptomechDevice):
         return pg.Transform3D(self._inverseBaseTransform)
 
     def setBaseTransform(self, tr):
-        """Set the base transform of the stage. 
+        """Set the base transform of the stage.
 
-        This sets the starting position and orientation of the stage before the 
+        This sets the starting position and orientation of the stage before the
         hardware-reported stage position is taken into account.
         """
         self._baseTransform = tr * 1  # *1 makes a copy
@@ -344,7 +344,7 @@ class Stage(Device, OptomechDevice):
             return self._lastPos[:]
 
     def globalPosition(self):
-        """Return the position of the local coordinate system origin relative to 
+        """Return the position of the local coordinate system origin relative to
         the global coordinate system.
         """
         # note: the origin of the local coordinate frame is the center position of the device.
@@ -357,7 +357,7 @@ class Stage(Device, OptomechDevice):
         raise NotImplementedError()
 
     def targetPosition(self):
-        """If the stage is moving, return the target position. Otherwise return 
+        """If the stage is moving, return the target position. Otherwise return
         the current position.
         """
         raise NotImplementedError()
@@ -384,12 +384,12 @@ class Stage(Device, OptomechDevice):
 
     def setDefaultSpeed(self, speed):
         """Set the default speed of the device when moving.
-        
-        Generally speeds are specified approximately in m/s, although many 
-        devices lack the capability to accurately set speed. This value may 
-        also be 'fast' to indicate the device should move as quickly as 
+
+        Generally speeds are specified approximately in m/s, although many
+        devices lack the capability to accurately set speed. This value may
+        also be 'fast' to indicate the device should move as quickly as
         possible, or 'slow' to indicate the device should minimize vibrations
-        while moving.        
+        while moving.
         """
         if speed not in ('fast', 'slow'):
             speed = abs(float(speed))
@@ -398,25 +398,25 @@ class Stage(Device, OptomechDevice):
     def isMoving(self):
         """Return True if the device is currently moving.
         """
-        raise NotImplementedError()        
+        raise NotImplementedError()
 
     def move(self, position, speed=None, progress=False, linear=False, **kwds) -> MoveFuture:
         """Move the device to a new position.
-        
+
         *position* specifies the absolute position in the stage coordinate system (as defined by the device)
 
         Optionally, *position* values may be None to indicate no movement along that axis.
-        
+
         If the *speed* argument is given, it temporarily overrides the default
         speed that was defined by the last call to setSpeed().
 
         If *linear* is True, then the movement is required to be in a straight line. By default,
         this argument is False, which means movement on each axis is conducted independently (the axis
         order depends on hardware).
-        
+
         If *progress* is True, then display a progress bar until the move is complete.
 
-        Return a MoveFuture instance that can be used to monitor the progress 
+        Return a MoveFuture instance that can be used to monitor the progress
         of the move.
         """
         if speed is None:
@@ -677,9 +677,9 @@ class MoveFuture(Future):
 
     def percentDone(self):
         """Return the percent of the move that has completed.
-        
+
         The default implementation calls getPosition on the device to determine
-        the percent complete. Devices that do not provide position updates while 
+        the percent complete. Devices that do not provide position updates while
         moving should reimplement this method.
         """
         if self.isDone():
@@ -753,7 +753,11 @@ class MovePathFuture(MoveFuture):
                             break
 
                     if self._stopRequested:
-                        self._taskDone(interrupted=True, error="Move was cancelled by external request")
+                        self._taskDone(
+                            interrupted=True,
+                            error=f"Move to {explanation} was cancelled by unknown external "
+                                  f"request.\nFull path: {self.path}",
+                        )
                         return
 
                     if fut.wasInterrupted():

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -703,6 +703,11 @@ class MultiPatchLogWidget(Qt.QWidget):
         if state:
             plot = self.buildPlotForUnits('Pa')
             plot.show()
+            colors = {
+                'regulator': (255, 255, 0),
+                'atmosphere': (0, 128, 255),
+                'user': (255, 0, 255),
+            }
             i = 0
             for data in self._devices.values():
                 pressure = data.get('pressure', None)
@@ -714,17 +719,16 @@ class MultiPatchLogWidget(Qt.QWidget):
                 # draw the regulator first so other sources are not obscured
                 sources = sorted(sources, key=lambda s: s[0].lower() != 'r')
                 for source in sources:
-                    mask = np.convolve(
-                        pressure['source'] == source, np.ones(3, dtype=bool), mode='same'
-                    )
+                    mask = pressure['source'] == source
                     this_pressure = np.full_like(time, np.nan)
                     this_pressure[mask] = pressure['pressure'][mask]
 
                     plot.plot(
                         time,
-                        this_pressure,
-                        pen=pg.mkPen(color=pg.intColor(i, len(sources) * len(self._devices))),
+                        this_pressure[:-1],
+                        pen=pg.mkPen(color=colors[source]),
                         name=f'Pressure: {source}',
+                        stepMode=True,
                     )
                     i += 1
         elif 'Pa' in self._plots_by_units:

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -714,14 +714,10 @@ class MultiPatchLogWidget(Qt.QWidget):
                 # draw the regulator first so other sources are not obscured
                 sources = sorted(sources, key=lambda s: s[0].lower() != 'r')
                 for source in sources:
-                    mask = pressure['source'] == source
-                    this_pressure = np.full_like(time, np.nan)
-                    indices = np.where(mask)[0]
-                    mask = np.unique(
-                        np.clip(
-                            np.concatenate([indices - 1, indices, indices + 1]), 0, len(time) - 1
-                        )
+                    mask = np.convolve(
+                        pressure['source'] == source, np.ones(3, dtype=bool), mode='same'
                     )
+                    this_pressure = np.full_like(time, np.nan)
                     this_pressure[mask] = pressure['pressure'][mask]
 
                     plot.plot(

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -639,7 +639,7 @@ class MultiPatchLogWidget(Qt.QWidget):
             self._testPulseAnalysisCheckboxes.append(cb)
             self._ctrl_layout.addWidget(cb)
         self._displayPressure = Qt.QCheckBox('Pressure')
-        self._displayPressure.toggled.connect(self._togglePressurePlot)
+        self._displayPressure.toggled.connect(self._togglePressurePlots)
         self._ctrl_layout.addWidget(self._displayPressure)
         self._sealAnalysisItems = {}
         self._displaySealAnalysis = Qt.QCheckBox('Seal Analysis')
@@ -699,15 +699,38 @@ class MultiPatchLogWidget(Qt.QWidget):
                 plot.removeItem(item)
             self._plot_items_by_plot[plot] = []
 
-    def _togglePressurePlot(self, state: bool):
+    def _togglePressurePlots(self, state: bool):
         if state:
             plot = self.buildPlotForUnits('Pa')
             plot.show()
+            i = 0
             for data in self._devices.values():
-                pressure = data.get('pressure', np.zeros(0, dtype=[('time', float), ('pressure', float)]))
+                pressure = data.get('pressure', None)
+                if pressure is None or len(pressure) == 0:
+                    plot.plot([], [], pen=pg.mkPen((0, len(TEST_PULSE_NUMPY_DTYPE))))
+                    continue
                 time = pressure['time'] - self.startTime()
-                if len(time) > 0:
-                    plot.plot(time, pressure['pressure'], pen=pg.mkPen((0, len(TEST_PULSE_NUMPY_DTYPE))), name='Pressure')
+                sources = np.unique(pressure['source'])
+                # draw the regulator first so other sources are not obscured
+                sources = sorted(sources, key=lambda s: s[0].lower() != 'r')
+                for source in sources:
+                    mask = pressure['source'] == source
+                    this_pressure = np.full_like(time, np.nan)
+                    indices = np.where(mask)[0]
+                    mask = np.unique(
+                        np.clip(
+                            np.concatenate([indices - 1, indices, indices + 1]), 0, len(time) - 1
+                        )
+                    )
+                    this_pressure[mask] = pressure['pressure'][mask]
+
+                    plot.plot(
+                        time,
+                        this_pressure,
+                        pen=pg.mkPen(color=pg.intColor(i, len(sources) * len(self._devices))),
+                        name=f'Pressure: {source}',
+                    )
+                    i += 1
         elif 'Pa' in self._plots_by_units:
             self._plots_by_units['Pa'].hide()
 


### PR DESCRIPTION
## Summary
- Splits pressure plot in MultiPatchLog to show each pressure source (regulator, user, etc.) as a separate colored line instead of a single combined trace
- Draws regulator source first so other sources aren't obscured
- Uses NaN gaps between segments so discontinuous source data doesn't get connected

## Test plan
- [ ] Open a MultiPatchLog file that has multiple pressure sources
- [ ] Toggle the Pressure checkbox and verify each source appears as a distinct colored line
- [ ] Verify regulator pressure is drawn behind other sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)